### PR TITLE
Add an ability to change font size in main.typ file

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -50,6 +50,9 @@
   force-performers: false,
   force-outline: false,
   hide-title: false,
+  font-size: 14pt,
+  small-font-size: 13pt,
+  indent: 1.5cm,
   body
 ) = {
   if year == auto {
@@ -58,7 +61,7 @@
 
   [#metadata(force-outline) <force-outline>]
 
-  show: gost-style.with(year: year, city: city, hide-title: hide-title)
+  show: gost-style.with(year: year, city: city, font-size: font-size, small-font-size: small-font-size, indent: indent, hide-title: hide-title)
 
   gost-common(ministry: ministry, organization: organization, udk: udk, gos-no: gos-no, inventory-no: inventory-no, performers: performers, approved-by: approved-by, agreed-by: agreed-by, report-type: report-type, about: about, part: part, bare-subject: bare-subject, research: research, subject: subject, stage: stage, manager: manager, city: city, year: year, force-performers: force-performers, force-outline: force-outline, hide-title: hide-title)
 

--- a/src/style.typ
+++ b/src/style.typ
@@ -1,20 +1,27 @@
 #import "component/headings.typ": headings, structural-heading-titles
 
-#let small-text = body => {
+#let small-font-state = state("size", none)
+
+/*#let small-text = body => {
   set text(size: 12pt)
+  body
+}*/
+
+#let small-text = body => context {
+  set text(size: small-font-state.get())
   body
 }
 
-#let indent = 1.25cm
-#let text-size = 14pt
+#let gost-style(year: none, city: "", font-size: 13pt, small-font-size: 10pt, indent: 1.5cm, hide-title: true, body) = {
 
-#let gost-style(year: none, city: "", hide-title: false, body) = {
+  small-font-state.update(x => small-font-size)
+
   set page(
     margin: (left: 30mm, right: 15mm, top: 20mm, bottom: 20mm)
   )
 
   set text(
-    size: text-size,
+    size: font-size,
     lang: "ru",
     hyphenate: false
   )
@@ -58,16 +65,13 @@
   
   set page(footer: context [
     #let page = here().page()
-    #align(center)[#{
-      if page == 1 {
-        if hide-title {} else {[#city #year]}
-      } 
-      else {page}
-    }]
+    #align(center)[
+        #if page == 1 {[#city #year]} else {page}
+    ]
   ])
 
   set bibliography(style: "gost-r-705-2008-numeric", title: structural-heading-titles.references)
   
-  show: headings(text-size, indent)
+  show: headings(font-size, indent)
   body
 }

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,4 +1,5 @@
-#import "@preview/typst-g7-32:0.0.1": gost, abstract
+//#import "@preview/typst-g7-32:0.0.1": gost, abstract
+#import "../src/export.typ": gost, abstract
 
 #show: gost.with(
   ministry: "Министерство образования и науки Российской Федерации


### PR DESCRIPTION
В предыдущей версии такой возможности не было - размер шрифта был задан в файле style.typ.
Добавив еще несколько аргументов в функции gost() и gost-style(), теперь можно быстро и удобно изменять размер шрифта текста из файла main.

В предыдущей версии не было возможности изменять размер текста — размер текста был предустановлен в файле style.typ.
После добавления пары аргументов в функции `gost()` и `gost-style()` появилась возможность быстро и удобно менять размер текста прямо из `main` файла.