### PR TITLE
Make testing command easier

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,7 @@ jobs:
           version: 0.2.2
 
       - name: Run test suite
-        run: tt run --use-system-fonts --no-fail-fast
+        run: tt run --no-fail-fast
 
       - name: Archive artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Флаг `--use-system-fonts` использует системные шрифты, что не являются поведением по умолчанию, и также не является портативным решением. Тесты проходят без него. Не вижу смысла в нём.

Отдельно, запуск `tt run --no-fail-fast` (или `tt r`) приводит к ошибке, но я так понимаю по той же причине, что и https://github.com/tingerrr/tytanic/issues/184. Так-то все тесты проходят хорошо (с `-e 'not template()'`). В CI какая-то другая старая версия, где этого не было (или шаблон не проверялся)?
